### PR TITLE
Fix/start crash

### DIFF
--- a/isometrik-meeting/src/main/java/io/isometrik/meeting/managers/RetrofitManager.java
+++ b/isometrik-meeting/src/main/java/io/isometrik/meeting/managers/RetrofitManager.java
@@ -1,5 +1,7 @@
 package io.isometrik.meeting.managers;
 
+import android.util.Log;
+
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 
@@ -69,8 +71,12 @@ public class RetrofitManager {
         httpClient.connectTimeout(connectTimeOut, TimeUnit.SECONDS);
 
         if (isometrik.getConfiguration().getLogVerbosity() == IMLogVerbosity.BODY) {
-            HttpLoggingInterceptor logging = new HttpLoggingInterceptor();
+            HttpLoggingInterceptor logging =
+                    new HttpLoggingInterceptor(message -> Log.d("IsometrikOkHttp", message));
             logging.setLevel(HttpLoggingInterceptor.Level.BODY);
+            logging.redactHeader("licenseKey");
+            logging.redactHeader("appSecret");
+            logging.redactHeader("userSecret");
             httpClient.addInterceptor(logging);
         }
 
@@ -153,4 +159,3 @@ public class RetrofitManager {
         }
     }
 }
-

--- a/isometrik-meeting/src/main/java/io/isometrik/ui/IsometrikCallSdk.java
+++ b/isometrik-meeting/src/main/java/io/isometrik/ui/IsometrikCallSdk.java
@@ -101,7 +101,7 @@ public class IsometrikCallSdk {
         IMConfiguration imConfiguration =
                 new IMConfiguration(applicationContext, licenseKey, appSecret, userSecret,
                         connectionString);
-        imConfiguration.setLogVerbosity(IMLogVerbosity.NONE);
+        imConfiguration.setLogVerbosity(IMLogVerbosity.BODY);
         imConfiguration.setRealtimeEventsVerbosity(IMRealtimeEventsVerbosity.NONE);
         isometrik = new Isometrik(imConfiguration);
         userSession = new UserSession(applicationContext);

--- a/isometrik-meeting/src/main/java/io/isometrik/ui/users/create/CreateUserActivity.java
+++ b/isometrik-meeting/src/main/java/io/isometrik/ui/users/create/CreateUserActivity.java
@@ -82,14 +82,11 @@ public class CreateUserActivity extends AppCompatActivity implements CreateUserC
     });
     ismActivityCreateUserBinding.ivProfilePic.setOnClickListener(v -> {
 
-      if ((ContextCompat.checkSelfPermission(CreateUserActivity.this, Manifest.permission.CAMERA)
-          != PackageManager.PERMISSION_GRANTED) || (ContextCompat.checkSelfPermission(
-          CreateUserActivity.this, Manifest.permission.WRITE_EXTERNAL_STORAGE)
-          != PackageManager.PERMISSION_GRANTED)) {
+      if (ContextCompat.checkSelfPermission(CreateUserActivity.this, Manifest.permission.CAMERA)
+          != PackageManager.PERMISSION_GRANTED) {
 
-        if ((ActivityCompat.shouldShowRequestPermissionRationale(CreateUserActivity.this,
-            Manifest.permission.CAMERA)) || (ActivityCompat.shouldShowRequestPermissionRationale(
-            CreateUserActivity.this, Manifest.permission.WRITE_EXTERNAL_STORAGE))) {
+        if (ActivityCompat.shouldShowRequestPermissionRationale(CreateUserActivity.this,
+            Manifest.permission.CAMERA)) {
           Snackbar snackbar = Snackbar.make(ismActivityCreateUserBinding.rlParent,
               R.string.ism_permission_image_capture, Snackbar.LENGTH_INDEFINITE)
               .setAction(getString(R.string.ism_ok), view1 -> requestPermissions());
@@ -164,7 +161,7 @@ public class CreateUserActivity extends AppCompatActivity implements CreateUserC
   private void requestPermissions() {
 
     ActivityCompat.requestPermissions(CreateUserActivity.this,
-        new String[] { Manifest.permission.CAMERA, Manifest.permission.WRITE_EXTERNAL_STORAGE }, 0);
+        new String[] { Manifest.permission.CAMERA }, 0);
   }
 
   @Override
@@ -277,16 +274,9 @@ public class CreateUserActivity extends AppCompatActivity implements CreateUserC
   @Override
   public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions,
       @NonNull int[] grantResults) {
-    boolean permissionDenied = false;
     if (requestCode == 0) {
 
-      for (int grantResult : grantResults) {
-        if (grantResult != PackageManager.PERMISSION_GRANTED) {
-          permissionDenied = true;
-          break;
-        }
-      }
-      if (permissionDenied) {
+      if (grantResults.length == 0 || grantResults[0] != PackageManager.PERMISSION_GRANTED) {
         Toast.makeText(this, getString(R.string.ism_permission_image_capture_denied),
             Toast.LENGTH_LONG).show();
       } else {

--- a/isometrik-meeting/src/main/java/io/isometrik/ui/users/edit/EditUserActivity.java
+++ b/isometrik-meeting/src/main/java/io/isometrik/ui/users/edit/EditUserActivity.java
@@ -88,14 +88,11 @@ public class EditUserActivity extends AppCompatActivity implements EditUserContr
     });
     ismActivityEditUserBinding.ibBack.setOnClickListener(v -> onBackPressed());
     ismActivityEditUserBinding.ibAddImage.setOnClickListener(v -> {
-      if ((ContextCompat.checkSelfPermission(EditUserActivity.this, Manifest.permission.CAMERA)
-          != PackageManager.PERMISSION_GRANTED) || (ContextCompat.checkSelfPermission(
-          EditUserActivity.this, Manifest.permission.WRITE_EXTERNAL_STORAGE)
-          != PackageManager.PERMISSION_GRANTED)) {
+      if (ContextCompat.checkSelfPermission(EditUserActivity.this, Manifest.permission.CAMERA)
+          != PackageManager.PERMISSION_GRANTED) {
 
-        if ((ActivityCompat.shouldShowRequestPermissionRationale(EditUserActivity.this,
-            Manifest.permission.CAMERA)) || (ActivityCompat.shouldShowRequestPermissionRationale(
-            EditUserActivity.this, Manifest.permission.WRITE_EXTERNAL_STORAGE))) {
+        if (ActivityCompat.shouldShowRequestPermissionRationale(EditUserActivity.this,
+            Manifest.permission.CAMERA)) {
           Snackbar snackbar = Snackbar.make(ismActivityEditUserBinding.rlParent,
               R.string.ism_permission_image_capture, Snackbar.LENGTH_INDEFINITE)
               .setAction(getString(R.string.ism_ok), view1 -> requestPermissions());
@@ -169,16 +166,9 @@ public class EditUserActivity extends AppCompatActivity implements EditUserContr
   @Override
   public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions,
       @NonNull int[] grantResults) {
-    boolean permissionDenied = false;
     if (requestCode == 0) {
 
-      for (int grantResult : grantResults) {
-        if (grantResult != PackageManager.PERMISSION_GRANTED) {
-          permissionDenied = true;
-          break;
-        }
-      }
-      if (permissionDenied) {
+      if (grantResults.length == 0 || grantResults[0] != PackageManager.PERMISSION_GRANTED) {
         Toast.makeText(this, getString(R.string.ism_permission_image_capture_denied),
             Toast.LENGTH_LONG).show();
       } else {
@@ -192,7 +182,7 @@ public class EditUserActivity extends AppCompatActivity implements EditUserContr
   private void requestPermissions() {
 
     ActivityCompat.requestPermissions(EditUserActivity.this,
-        new String[] { Manifest.permission.CAMERA, Manifest.permission.WRITE_EXTERNAL_STORAGE }, 0);
+        new String[] { Manifest.permission.CAMERA }, 0);
   }
 
   /**


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request addresses crash issues related to camera permission handling in the user creation and editing activities. It simplifies permission checks by removing redundant storage permission requests, requesting only camera permission, and adjusts permission result handling to prevent start crashes when permissions are denied. Additionally, it enhances HTTP logging by redacting sensitive headers and improves logging configuration. Overall, these changes improve app stability during camera permission requests and enhance security in network logging.
<!-- kody-pr-summary:end -->