### PR TITLE
fix:

### DIFF
--- a/isometrik-meeting/src/main/AndroidManifest.xml
+++ b/isometrik-meeting/src/main/AndroidManifest.xml
@@ -4,13 +4,18 @@
     package="io.isometrik.meeting">
 
   <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
-  <uses-feature android:name="android.hardware.camera" />
-  <uses-feature android:name="android.hardware.camera.autofocus" />
+  <uses-feature
+      android:name="android.hardware.camera"
+      android:required="true" />
+  <uses-feature
+      android:name="android.hardware.camera.autofocus"
+      android:required="false" />
 
-  <uses-feature android:name="android.hardware.sensor.gyroscope" />
+  <uses-feature
+      android:name="android.hardware.sensor.gyroscope"
+      android:required="false" />
 
   <uses-permission android:name="android.permission.CAMERA" />
-  <uses-permission android:name="android.hardware.camera.autofocus" />
   <uses-permission android:name="android.permission.RECORD_AUDIO" />
   <uses-permission android:name="android.permission.INTERNET" />
   <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
@@ -28,7 +33,6 @@
       android:allowBackup="false"
       android:label="@string/ism_app_name"
       android:networkSecurityConfig="@xml/network_security_config"
-      android:requestLegacyExternalStorage="true"
       android:theme="@style/Theme.AppCompat.Light.NoActionBar">
 
     <activity

--- a/isometrik-meeting/src/main/java/io/isometrik/ui/users/create/CreateUserActivity.java
+++ b/isometrik-meeting/src/main/java/io/isometrik/ui/users/create/CreateUserActivity.java
@@ -82,14 +82,11 @@ public class CreateUserActivity extends AppCompatActivity implements CreateUserC
     });
     ismActivityCreateUserBinding.ivProfilePic.setOnClickListener(v -> {
 
-      if ((ContextCompat.checkSelfPermission(CreateUserActivity.this, Manifest.permission.CAMERA)
-          != PackageManager.PERMISSION_GRANTED) || (ContextCompat.checkSelfPermission(
-          CreateUserActivity.this, Manifest.permission.WRITE_EXTERNAL_STORAGE)
-          != PackageManager.PERMISSION_GRANTED)) {
+      if (ContextCompat.checkSelfPermission(CreateUserActivity.this, Manifest.permission.CAMERA)
+          != PackageManager.PERMISSION_GRANTED) {
 
-        if ((ActivityCompat.shouldShowRequestPermissionRationale(CreateUserActivity.this,
-            Manifest.permission.CAMERA)) || (ActivityCompat.shouldShowRequestPermissionRationale(
-            CreateUserActivity.this, Manifest.permission.WRITE_EXTERNAL_STORAGE))) {
+        if (ActivityCompat.shouldShowRequestPermissionRationale(CreateUserActivity.this,
+            Manifest.permission.CAMERA)) {
           Snackbar snackbar = Snackbar.make(ismActivityCreateUserBinding.rlParent,
               R.string.ism_permission_image_capture, Snackbar.LENGTH_INDEFINITE)
               .setAction(getString(R.string.ism_ok), view1 -> requestPermissions());
@@ -164,7 +161,7 @@ public class CreateUserActivity extends AppCompatActivity implements CreateUserC
   private void requestPermissions() {
 
     ActivityCompat.requestPermissions(CreateUserActivity.this,
-        new String[] { Manifest.permission.CAMERA, Manifest.permission.WRITE_EXTERNAL_STORAGE }, 0);
+        new String[] { Manifest.permission.CAMERA }, 0);
   }
 
   @Override

--- a/isometrik-meeting/src/main/java/io/isometrik/ui/users/edit/EditUserActivity.java
+++ b/isometrik-meeting/src/main/java/io/isometrik/ui/users/edit/EditUserActivity.java
@@ -88,14 +88,11 @@ public class EditUserActivity extends AppCompatActivity implements EditUserContr
     });
     ismActivityEditUserBinding.ibBack.setOnClickListener(v -> onBackPressed());
     ismActivityEditUserBinding.ibAddImage.setOnClickListener(v -> {
-      if ((ContextCompat.checkSelfPermission(EditUserActivity.this, Manifest.permission.CAMERA)
-          != PackageManager.PERMISSION_GRANTED) || (ContextCompat.checkSelfPermission(
-          EditUserActivity.this, Manifest.permission.WRITE_EXTERNAL_STORAGE)
-          != PackageManager.PERMISSION_GRANTED)) {
+      if (ContextCompat.checkSelfPermission(EditUserActivity.this, Manifest.permission.CAMERA)
+          != PackageManager.PERMISSION_GRANTED) {
 
-        if ((ActivityCompat.shouldShowRequestPermissionRationale(EditUserActivity.this,
-            Manifest.permission.CAMERA)) || (ActivityCompat.shouldShowRequestPermissionRationale(
-            EditUserActivity.this, Manifest.permission.WRITE_EXTERNAL_STORAGE))) {
+        if (ActivityCompat.shouldShowRequestPermissionRationale(EditUserActivity.this,
+            Manifest.permission.CAMERA)) {
           Snackbar snackbar = Snackbar.make(ismActivityEditUserBinding.rlParent,
               R.string.ism_permission_image_capture, Snackbar.LENGTH_INDEFINITE)
               .setAction(getString(R.string.ism_ok), view1 -> requestPermissions());
@@ -192,7 +189,7 @@ public class EditUserActivity extends AppCompatActivity implements EditUserContr
   private void requestPermissions() {
 
     ActivityCompat.requestPermissions(EditUserActivity.this,
-        new String[] { Manifest.permission.CAMERA, Manifest.permission.WRITE_EXTERNAL_STORAGE }, 0);
+        new String[] { Manifest.permission.CAMERA }, 0);
   }
 
   /**


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request updates the permission handling logic for camera access in the CreateUserActivity and EditUserActivity classes. Specifically, it simplifies the permission request process by removing the request for WRITE_EXTERNAL_STORAGE permission and adjusting the rationale check to only consider the CAMERA permission. These changes likely aim to streamline permission requests, reduce unnecessary permission prompts, and align with updated Android permission best practices.
<!-- kody-pr-summary:end -->