### PR TITLE
fix:

### DIFF
--- a/isometrik-meeting/src/main/java/io/isometrik/ui/users/create/CreateUserActivity.java
+++ b/isometrik-meeting/src/main/java/io/isometrik/ui/users/create/CreateUserActivity.java
@@ -36,6 +36,7 @@ import io.isometrik.ui.users.create.CreateUserContract;
 import io.isometrik.ui.users.list.UsersActivity;
 import io.isometrik.ui.utils.AlertProgress;
 import io.isometrik.ui.utils.Constants;
+import io.isometrik.ui.utils.GalleryImagePicker;
 import com.bumptech.glide.Glide;
 
 /**
@@ -55,6 +56,7 @@ public class CreateUserActivity extends AppCompatActivity implements CreateUserC
   private boolean cleanUpRequested = false;
   private IsmActivityCreateUserBinding ismActivityCreateUserBinding;
   private ActivityResultLauncher<Intent> cameraActivityLauncher;
+  private GalleryImagePicker galleryImagePicker;
   private AlertDialog uploadProgressDialog;
   private CircularProgressIndicator circularProgressIndicator;
 
@@ -80,31 +82,7 @@ public class CreateUserActivity extends AppCompatActivity implements CreateUserC
       //      Toast.LENGTH_SHORT).show();
       //}
     });
-    ismActivityCreateUserBinding.ivProfilePic.setOnClickListener(v -> {
-
-      if (ContextCompat.checkSelfPermission(CreateUserActivity.this, Manifest.permission.CAMERA)
-          != PackageManager.PERMISSION_GRANTED) {
-
-        if (ActivityCompat.shouldShowRequestPermissionRationale(CreateUserActivity.this,
-            Manifest.permission.CAMERA)) {
-          Snackbar snackbar = Snackbar.make(ismActivityCreateUserBinding.rlParent,
-              R.string.ism_permission_image_capture, Snackbar.LENGTH_INDEFINITE)
-              .setAction(getString(R.string.ism_ok), view1 -> requestPermissions());
-
-          snackbar.show();
-
-          ((TextView) snackbar.getView()
-              .findViewById(com.google.android.material.R.id.snackbar_text)).setGravity(
-              Gravity.CENTER_HORIZONTAL);
-        } else {
-
-          requestPermissions();
-        }
-      } else {
-
-        requestImageCapture();
-      }
-    });
+    ismActivityCreateUserBinding.ivProfilePic.setOnClickListener(v -> showImageSourceOptions());
     ismActivityCreateUserBinding.ibBack.setOnClickListener(v -> onBackPressed());
     ismActivityCreateUserBinding.tvSelectUser.setOnClickListener(v -> onBackPressed());
 
@@ -134,6 +112,19 @@ public class CreateUserActivity extends AppCompatActivity implements CreateUserC
                 .show();
           }
         });
+    galleryImagePicker = new GalleryImagePicker(this, pickedImageFile -> {
+      imageFile = pickedImageFile;
+
+      try {
+        Glide.with(this)
+            .load(imageFile.getAbsolutePath())
+            .transform(new CircleCrop())
+            .into(ismActivityCreateUserBinding.ivProfilePic);
+      } catch (IllegalArgumentException | NullPointerException ignore) {
+
+      }
+      ismActivityCreateUserBinding.ivRemoveUserImage.setVisibility(View.VISIBLE);
+    });
 
     ismActivityCreateUserBinding.ivRemoveUserImage.setOnClickListener(v -> {
       imageFile = null;
@@ -162,6 +153,47 @@ public class CreateUserActivity extends AppCompatActivity implements CreateUserC
 
     ActivityCompat.requestPermissions(CreateUserActivity.this,
         new String[] { Manifest.permission.CAMERA }, 0);
+  }
+
+  private void showImageSourceOptions() {
+    new AlertDialog.Builder(this)
+        .setTitle(getString(R.string.ism_image_selection_title))
+        .setItems(new String[] {
+            getString(R.string.ism_image_selection_camera),
+            getString(R.string.ism_image_selection_gallery)
+        }, (dialog, which) -> {
+          if (which == 0) {
+            requestCameraCapture();
+          } else {
+            galleryImagePicker.pickImage();
+          }
+        })
+        .show();
+  }
+
+  private void requestCameraCapture() {
+    if (ContextCompat.checkSelfPermission(CreateUserActivity.this, Manifest.permission.CAMERA)
+        != PackageManager.PERMISSION_GRANTED) {
+
+      if (ActivityCompat.shouldShowRequestPermissionRationale(CreateUserActivity.this,
+          Manifest.permission.CAMERA)) {
+        Snackbar snackbar = Snackbar.make(ismActivityCreateUserBinding.rlParent,
+            R.string.ism_permission_image_capture, Snackbar.LENGTH_INDEFINITE)
+            .setAction(getString(R.string.ism_ok), view1 -> requestPermissions());
+
+        snackbar.show();
+
+        ((TextView) snackbar.getView()
+            .findViewById(com.google.android.material.R.id.snackbar_text)).setGravity(
+            Gravity.CENTER_HORIZONTAL);
+      } else {
+
+        requestPermissions();
+      }
+    } else {
+
+      requestImageCapture();
+    }
   }
 
   @Override

--- a/isometrik-meeting/src/main/java/io/isometrik/ui/users/edit/EditUserActivity.java
+++ b/isometrik-meeting/src/main/java/io/isometrik/ui/users/edit/EditUserActivity.java
@@ -36,6 +36,7 @@ import io.isometrik.ui.camera.CameraActivity;
 import io.isometrik.meeting.databinding.IsmActivityEditUserBinding;
 import io.isometrik.ui.utils.AlertProgress;
 import com.bumptech.glide.Glide;
+import io.isometrik.ui.utils.GalleryImagePicker;
 import io.isometrik.ui.utils.PlaceholderUtils;
 import io.isometrik.ui.utils.UserSession;
 
@@ -63,6 +64,7 @@ public class EditUserActivity extends AppCompatActivity implements EditUserContr
 
   private IsmActivityEditUserBinding ismActivityEditUserBinding;
   private ActivityResultLauncher<Intent> cameraActivityLauncher;
+  private GalleryImagePicker galleryImagePicker;
   private AlertDialog uploadProgressDialog;
   private CircularProgressIndicator circularProgressIndicator;
 
@@ -87,30 +89,7 @@ public class EditUserActivity extends AppCompatActivity implements EditUserContr
           profilePicUpdated);
     });
     ismActivityEditUserBinding.ibBack.setOnClickListener(v -> onBackPressed());
-    ismActivityEditUserBinding.ibAddImage.setOnClickListener(v -> {
-      if (ContextCompat.checkSelfPermission(EditUserActivity.this, Manifest.permission.CAMERA)
-          != PackageManager.PERMISSION_GRANTED) {
-
-        if (ActivityCompat.shouldShowRequestPermissionRationale(EditUserActivity.this,
-            Manifest.permission.CAMERA)) {
-          Snackbar snackbar = Snackbar.make(ismActivityEditUserBinding.rlParent,
-              R.string.ism_permission_image_capture, Snackbar.LENGTH_INDEFINITE)
-              .setAction(getString(R.string.ism_ok), view1 -> requestPermissions());
-
-          snackbar.show();
-
-          ((TextView) snackbar.getView()
-              .findViewById(com.google.android.material.R.id.snackbar_text)).setGravity(
-              Gravity.CENTER_HORIZONTAL);
-        } else {
-
-          requestPermissions();
-        }
-      } else {
-
-        requestImageCapture();
-      }
-    });
+    ismActivityEditUserBinding.ibAddImage.setOnClickListener(v -> showImageSourceOptions());
 
     cameraActivityLauncher =
         registerForActivityResult(new ActivityResultContracts.StartActivityForResult(), result -> {
@@ -139,6 +118,19 @@ public class EditUserActivity extends AppCompatActivity implements EditUserContr
                 .show();
           }
         });
+    galleryImagePicker = new GalleryImagePicker(this, pickedImageFile -> {
+      imageFile = pickedImageFile;
+
+      try {
+        Glide.with(this)
+            .load(imageFile.getAbsolutePath())
+            .transform(new CircleCrop())
+            .into(ismActivityEditUserBinding.ivProfilePic);
+      } catch (IllegalArgumentException | NullPointerException ignore) {
+
+      }
+      profilePicUpdated = true;
+    });
   }
 
 
@@ -190,6 +182,47 @@ public class EditUserActivity extends AppCompatActivity implements EditUserContr
 
     ActivityCompat.requestPermissions(EditUserActivity.this,
         new String[] { Manifest.permission.CAMERA }, 0);
+  }
+
+  private void showImageSourceOptions() {
+    new AlertDialog.Builder(this)
+        .setTitle(getString(R.string.ism_image_selection_title))
+        .setItems(new String[] {
+            getString(R.string.ism_image_selection_camera),
+            getString(R.string.ism_image_selection_gallery)
+        }, (dialog, which) -> {
+          if (which == 0) {
+            requestCameraCapture();
+          } else {
+            galleryImagePicker.pickImage();
+          }
+        })
+        .show();
+  }
+
+  private void requestCameraCapture() {
+    if (ContextCompat.checkSelfPermission(EditUserActivity.this, Manifest.permission.CAMERA)
+        != PackageManager.PERMISSION_GRANTED) {
+
+      if (ActivityCompat.shouldShowRequestPermissionRationale(EditUserActivity.this,
+          Manifest.permission.CAMERA)) {
+        Snackbar snackbar = Snackbar.make(ismActivityEditUserBinding.rlParent,
+            R.string.ism_permission_image_capture, Snackbar.LENGTH_INDEFINITE)
+            .setAction(getString(R.string.ism_ok), view1 -> requestPermissions());
+
+        snackbar.show();
+
+        ((TextView) snackbar.getView()
+            .findViewById(com.google.android.material.R.id.snackbar_text)).setGravity(
+            Gravity.CENTER_HORIZONTAL);
+      } else {
+
+        requestPermissions();
+      }
+    } else {
+
+      requestImageCapture();
+    }
   }
 
   /**

--- a/isometrik-meeting/src/main/java/io/isometrik/ui/utils/GalleryImagePicker.java
+++ b/isometrik-meeting/src/main/java/io/isometrik/ui/utils/GalleryImagePicker.java
@@ -1,0 +1,80 @@
+package io.isometrik.ui.utils;
+
+import android.content.Context;
+import android.net.Uri;
+import android.widget.Toast;
+
+import androidx.activity.result.ActivityResultLauncher;
+import androidx.activity.result.PickVisualMediaRequest;
+import androidx.activity.result.contract.ActivityResultContracts;
+import androidx.annotation.NonNull;
+import androidx.appcompat.app.AppCompatActivity;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+import io.isometrik.meeting.R;
+
+/**
+ * Uses Android's photo picker to select an image without storage permissions.
+ */
+public class GalleryImagePicker {
+
+  public interface Callback {
+    void onImagePicked(@NonNull File imageFile);
+  }
+
+  private final AppCompatActivity activity;
+  private final Callback callback;
+  private final ActivityResultLauncher<PickVisualMediaRequest> pickerLauncher;
+
+  public GalleryImagePicker(@NonNull AppCompatActivity activity, @NonNull Callback callback) {
+    this.activity = activity;
+    this.callback = callback;
+    pickerLauncher = activity.registerForActivityResult(
+        new ActivityResultContracts.PickVisualMedia(), this::handlePickedImage);
+  }
+
+  public void pickImage() {
+    pickerLauncher.launch(new PickVisualMediaRequest.Builder()
+        .setMediaType(ActivityResultContracts.PickVisualMedia.ImageOnly.INSTANCE)
+        .build());
+  }
+
+  private void handlePickedImage(Uri imageUri) {
+    if (imageUri == null) {
+      Toast.makeText(activity, R.string.ism_image_selection_canceled, Toast.LENGTH_LONG).show();
+      return;
+    }
+
+    try {
+      callback.onImagePicked(copyImageToAppStorage(activity, imageUri));
+    } catch (IOException e) {
+      Toast.makeText(activity, R.string.ism_image_selection_failure, Toast.LENGTH_LONG).show();
+    }
+  }
+
+  private static File copyImageToAppStorage(@NonNull Context context, @NonNull Uri imageUri)
+      throws IOException {
+    File imageFile =
+        ImageUtil.createImageFile(String.valueOf(System.currentTimeMillis()), false, context);
+
+    try (InputStream inputStream = context.getContentResolver().openInputStream(imageUri);
+        OutputStream outputStream = new FileOutputStream(imageFile)) {
+      if (inputStream == null) {
+        throw new IOException("Unable to open selected image.");
+      }
+
+      byte[] buffer = new byte[8192];
+      int bytesRead;
+      while ((bytesRead = inputStream.read(buffer)) != -1) {
+        outputStream.write(buffer, 0, bytesRead);
+      }
+    }
+
+    return imageFile;
+  }
+}

--- a/isometrik-meeting/src/main/res/values/strings.xml
+++ b/isometrik-meeting/src/main/res/values/strings.xml
@@ -31,6 +31,11 @@
     <string name="ism_permission_image_capture_denied">Permission to capture image denied!!</string>
     <string name="ism_image_capture_canceled">Image capture canceled!!</string>
     <string name="ism_image_capture_failure">Failed to capture image!!</string>
+    <string name="ism_image_selection_title">Select profile image</string>
+    <string name="ism_image_selection_camera">Take photo</string>
+    <string name="ism_image_selection_gallery">Choose from gallery</string>
+    <string name="ism_image_selection_canceled">Image selection canceled!!</string>
+    <string name="ism_image_selection_failure">Failed to select image!!</string>
     <string name="ism_ok">OK</string>
     <string name="ism_invalid_username">Add user name to continue!!</string>
     <string name="ism_invalid_user_identifier">Add user identifier to continue!!</string>


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request introduces a unified image selection feature in the user creation and editing activities by replacing the previous camera permission and capture logic with a new `GalleryImagePicker` utility. It enables users to choose a profile picture either from the device's camera or gallery through a simple dialog, streamlining the image selection process. The implementation handles runtime permissions for camera access, manages image picking via Android's photo picker, and updates the profile image view with the selected picture, including circular cropping. Overall, these changes improve the user experience by providing a consistent and permission-aware way to select or capture profile images in the app.
<!-- kody-pr-summary:end -->